### PR TITLE
Adding __invoke to support closures

### DIFF
--- a/src/SafeObject.php
+++ b/src/SafeObject.php
@@ -67,6 +67,14 @@ class SafeObject implements ArrayAccess
     {
         return View::escape(call_user_func_array([$this->object, $method], $args));
     }
+    
+    /**
+     * @return mixed
+     */
+    public function __invoke()
+    {
+        return View::escape(call_user_func_array($this->object, func_get_args()));
+    }
 
     /**
      * @return string


### PR DESCRIPTION
In Traq\Installer\Controllers\AppController you set installStep as a closure.  Then in license_agreement.phtml you have the form action as $installStep("database_info") which fails with a fatal error stating that "Function name must be a string".  A var_dump shows that the $installStep var is actually the closure wrapped in a SafeObject but that it doesn't route correctly to the enclosed closure.  By adding the __invoke function we can allow a SafeObject to be used as a closure and function as expected.
